### PR TITLE
Erlport dependency version changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Close the monitor:
 ## FAQ
 1. In the Erlang/OTP 21, erlport may not be compiled, because the latest version was not reflected in the official Erlport GitHub.
 
-  - SOL) Change the version of erlport manually in <b>mix.exs</b>. (As of October, 2018, the "0.10.0" version worked.)
+  - SOL) Change the version of erlport manually in <b>mix.exs</b>. (As of October, 2018, the "0.10.0" version worked.https://github.com/hdima/erlport.git)
   ```
   defp deps do
       [

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Close the monitor:
 ## FAQ
 1. In the Erlang/OTP 21, erlport may not be compiled, because the latest version was not reflected in the official Erlport GitHub.
 
-  - SOL) Change the version of erlport manually in <b>mix.exs</b>. (As of October 23, 2018, this version worked.)
+  - SOL) Change the version of erlport manually in <b>mix.exs</b>. (As of October, 2018, this version worked.)
   ```
   defp deps do
       [

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Close the monitor:
     {"monitor" {"action": "close"}}
   
 ## FAQ
-1. In the Erlang/OTP 21, erlport may not be compiled, because the latest version was not reflected in the official Erlport GitHub.
+<b>1. In the Erlang/OTP 21, erlport may not be compiled, because the latest version was not reflected in the official Erlport GitHub.</b>
 
   - SOL) Change the version of erlport manually in <b>mix.exs</b>. As of October, 2018, the "0.10.0" version worked. See this https://github.com/hdima/erlport
     ```
@@ -152,7 +152,7 @@ Close the monitor:
     end
     ```
   
-2. Failed to fetch record for 'hexpm/poolboy' from registry (using cache)
+<b>2. Failed to fetch record for 'hexpm/poolboy' from registry (using cache)</b>
 
   - SOL) This was a cache problem, remove the cache file and try again.
     ```

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Close the monitor:
     rm "~/.hex/cache.ets"
     ```
 <b>3. When you run a client, if you get the following error.</b>
+
     ```
     $ ./example
     terminate called after throwing an instance of 'boost::system::system_error'

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The server is written in elixir, enabling a distributed infrastructure. Where ea
   3. [Demo](#demo)
   4. [Distributed Server](#distributed-server)
   5. [API specification](#api-specification)
+  6. [Bug reporting](#bug-reporting)
 
 ## Dependencies
 
@@ -137,3 +138,5 @@ Start the monitor:
 Close the monitor:
 
     {"monitor" {"action": "close"}}
+  
+## Bug reporting

--- a/README.md
+++ b/README.md
@@ -142,7 +142,8 @@ Close the monitor:
 ## FAQ
 1. In the Erlang/OTP 21, erlport may not be compiled, because the latest version was not reflected in the official Erlport GitHub.
 
-  - SOL) Change the version of erlport manually in <b>mix.exs</b>. (As of October, 2018, the "0.10.0" version worked. See this https://github.com/hdima/erlport.git)
+  - SOL) Change the version of erlport manually in <b>mix.exs</b>. 
+  As of October, 2018, the "0.10.0" version worked. See this https://github.com/hdima/erlport.git
   ```
   defp deps do
       [

--- a/README.md
+++ b/README.md
@@ -160,11 +160,12 @@ Close the monitor:
     ```
     
 <b>3. When you run a client, if you get the following error.</b>
-
+    ```
     $ ./example
     terminate called after throwing an instance of 'boost::system::system_error'
       what():  Connection refused
     Aborted (core dumped)    
+    ```
 
 
   - SOL) I changed the line 17 code const std::string host = "kurg.org"; to const std::string host = "127.0.0.1"; in example.cpp and then the program is working correctly.

--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Close the monitor:
     ```
     rm "~/.hex/cache.ets"
     ```
+    
 <b>3. When you run a client, if you get the following error.</b>
 
     ```

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Close the monitor:
   
 ## FAQ
 1. In the Erlang/OTP 21, erlport may not be compiled, because the latest version was not reflected in the official Erlport GitHub.
+
 SOL) Change the version of erlport manually in <b>mix.exs</b>. (As of October 23, 2018, this version worked.)
 ```
 defp deps do

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Close the monitor:
 ## FAQ
 1. In the Erlang/OTP 21, erlport may not be compiled, because the latest version was not reflected in the official Erlport GitHub.
 
-  - SOL) Change the version of erlport manually in <b>mix.exs</b>. (As of October, 2018, "0.10.0" version worked.)
+  - SOL) Change the version of erlport manually in <b>mix.exs</b>. (As of October, 2018, the "0.10.0" version worked.)
   ```
   defp deps do
       [

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The server is written in elixir, enabling a distributed infrastructure. Where ea
   3. [Demo](#demo)
   4. [Distributed Server](#distributed-server)
   5. [API specification](#api-specification)
-  6. [Bug reporting](#bug-reporting)
+  6. [FAQ](#faq)
 
 ## Dependencies
 
@@ -139,4 +139,4 @@ Close the monitor:
 
     {"monitor" {"action": "close"}}
   
-## Bug reporting
+## FAQ

--- a/README.md
+++ b/README.md
@@ -140,3 +140,13 @@ Close the monitor:
     {"monitor" {"action": "close"}}
   
 ## FAQ
+1. In the Erlang/OTP 21, erlport may not be compiled, because the latest version was not reflected in the official Erlport GitHub.
+SOL) Change the version of erlport manually in <b>mix.exs</b>. (As of October 23, 2018, this version worked.)
+```
+defp deps do
+    [
+      {:erlport, "~> 0.10.0"},
+      {:poolboy, "~> 1.5"}
+    ]
+end
+```

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Close the monitor:
 1. In the Erlang/OTP 21, erlport may not be compiled, because the latest version was not reflected in the official Erlport GitHub.
 
   - SOL) Change the version of erlport manually in <b>mix.exs</b>. 
-  As of October, 2018, the "0.10.0" version worked. See this https://github.com/hdima/erlport.git
+  As of October, 2018, the "0.10.0" version worked. See this https://github.com/hdima/erlport
   ```
   defp deps do
       [

--- a/README.md
+++ b/README.md
@@ -161,12 +161,11 @@ Close the monitor:
     
 <b>3. When you run a client, if you get the following error.</b>
 
-    ```
     $ ./example
     terminate called after throwing an instance of 'boost::system::system_error'
       what():  Connection refused
     Aborted (core dumped)    
-    ```
+
 
   - SOL) I changed the line 17 code const std::string host = "kurg.org"; to const std::string host = "127.0.0.1"; in example.cpp and then the program is working correctly.
     

--- a/README.md
+++ b/README.md
@@ -158,3 +158,13 @@ Close the monitor:
     ```
     rm "~/.hex/cache.ets"
     ```
+<b>3. When you run a client, if you get the following error.
+    ```
+    $ ./example
+    terminate called after throwing an instance of 'boost::system::system_error'
+      what():  Connection refused
+    Aborted (core dumped)    
+    ```
+
+  - SOL) I changed the line 17 code const std::string host = "kurg.org"; to const std::string host = "127.0.0.1"; in example.cpp and then the program is working correctly.
+    

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Close the monitor:
 ## FAQ
 1. In the Erlang/OTP 21, erlport may not be compiled, because the latest version was not reflected in the official Erlport GitHub.
 
-    - SOL) Change the version of erlport manually in <b>mix.exs</b>. (As of October 23, 2018, this version worked.)
+  - SOL) Change the version of erlport manually in <b>mix.exs</b>. (As of October 23, 2018, this version worked.)
   ```
   defp deps do
       [

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Close the monitor:
 ## FAQ
 1. In the Erlang/OTP 21, erlport may not be compiled, because the latest version was not reflected in the official Erlport GitHub.
 
-  - SOL) Change the version of erlport manually in <b>mix.exs</b>. (As of October, 2018, this version worked.)
+  - SOL) Change the version of erlport manually in <b>mix.exs</b>. (As of October, 2018, "0.10.0" version worked.)
   ```
   defp deps do
       [

--- a/README.md
+++ b/README.md
@@ -159,12 +159,12 @@ Close the monitor:
     rm "~/.hex/cache.ets"
     ```
     
-<b>3. When you run a client, "what():  Connection refused." error occurs</b>
+<b>3. When you run a client, if "what():  Connection refused." error occurs</b>
   
-  - SOL) I changed the line 17 code const std::string host = "kurg.org"; to const std::string host = "127.0.0.1"; in example.cpp and then the program is working correctly. This is to use your own server instance.
+  - SOL) If you use your own server instance, changed the line 17 code const std::string host = "kurg.org"; to const std::string host = "127.0.0.1"; in example.cpp and try again.
     ```
     const std::string environment = "CartPole-v0";
-    const std::string host = "127.0.0.1";
+    const std::string host = "127.0.0.1"; // Change this line
     const std::string port = "4040";
     ```
     

--- a/README.md
+++ b/README.md
@@ -142,9 +142,7 @@ Close the monitor:
 ## FAQ
 1. In the Erlang/OTP 21, erlport may not be compiled, because the latest version was not reflected in the official Erlport GitHub.
 
-  - SOL) Change the version of erlport manually in <b>mix.exs</b>. 
-  
-  As of October, 2018, the "0.10.0" version worked. See this https://github.com/hdima/erlport
+  - SOL) Change the version of erlport manually in <b>mix.exs</b>. As of October, 2018, the "0.10.0" version worked. See this https://github.com/hdima/erlport
   ```
   defp deps do
       [

--- a/README.md
+++ b/README.md
@@ -159,12 +159,12 @@ Close the monitor:
     rm "~/.hex/cache.ets"
     ```
     
-<b>3. When you run a client, <b>what():  Connection refused.</b> error occurs</b>
+<b>3. When you run a client, "what():  Connection refused." error occurs</b>
   
   - SOL) I changed the line 17 code const std::string host = "kurg.org"; to const std::string host = "127.0.0.1"; in example.cpp and then the program is working correctly. This is to use your own server instance.
-  ```
-  const std::string environment = "CartPole-v0";
-  const std::string host = "127.0.0.1";
-  const std::string port = "4040";
-  ```
+    ```
+    const std::string environment = "CartPole-v0";
+    const std::string host = "127.0.0.1";
+    const std::string port = "4040";
+    ```
     

--- a/README.md
+++ b/README.md
@@ -159,14 +159,12 @@ Close the monitor:
     rm "~/.hex/cache.ets"
     ```
     
-<b>3. When you run a client, if you get the following error.</b>
-    ```
-    $ ./example
-    terminate called after throwing an instance of 'boost::system::system_error'
-      what():  Connection refused
-    Aborted (core dumped)    
-    ```
-
-
-  - SOL) I changed the line 17 code const std::string host = "kurg.org"; to const std::string host = "127.0.0.1"; in example.cpp and then the program is working correctly.
+<b>3. When you run a client, <b>what():  Connection refused.</b> error occurs
+  
+  - SOL) I changed the line 17 code const std::string host = "kurg.org"; to const std::string host = "127.0.0.1"; in example.cpp and then the program is working correctly. This is to use your own server instance.
+  ```
+  const std::string environment = "CartPole-v0";
+  const std::string host = "127.0.0.1";
+  const std::string port = "4040";
+  ```
     

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Close the monitor:
 1. In the Erlang/OTP 21, erlport may not be compiled, because the latest version was not reflected in the official Erlport GitHub.
 
   - SOL) Change the version of erlport manually in <b>mix.exs</b>. 
+  
   As of October, 2018, the "0.10.0" version worked. See this https://github.com/hdima/erlport
   ```
   defp deps do

--- a/README.md
+++ b/README.md
@@ -142,12 +142,12 @@ Close the monitor:
 ## FAQ
 1. In the Erlang/OTP 21, erlport may not be compiled, because the latest version was not reflected in the official Erlport GitHub.
 
-SOL) Change the version of erlport manually in <b>mix.exs</b>. (As of October 23, 2018, this version worked.)
-```
-defp deps do
-    [
-      {:erlport, "~> 0.10.0"},
-      {:poolboy, "~> 1.5"}
-    ]
-end
-```
+  SOL) Change the version of erlport manually in <b>mix.exs</b>. (As of October 23, 2018, this version worked.)
+  ```
+  defp deps do
+      [
+        {:erlport, "~> 0.10.0"},
+        {:poolboy, "~> 1.5"}
+      ]
+  end
+  ```

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Close the monitor:
 ## FAQ
 1. In the Erlang/OTP 21, erlport may not be compiled, because the latest version was not reflected in the official Erlport GitHub.
 
-  - SOL) Change the version of erlport manually in <b>mix.exs</b>. (As of October, 2018, the "0.10.0" version worked.https://github.com/hdima/erlport.git)
+  - SOL) Change the version of erlport manually in <b>mix.exs</b>. (As of October, 2018, the "0.10.0" version worked. See this https://github.com/hdima/erlport.git)
   ```
   defp deps do
       [

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Close the monitor:
 ## FAQ
 1. In the Erlang/OTP 21, erlport may not be compiled, because the latest version was not reflected in the official Erlport GitHub.
 
-  SOL) Change the version of erlport manually in <b>mix.exs</b>. (As of October 23, 2018, this version worked.)
+    - SOL) Change the version of erlport manually in <b>mix.exs</b>. (As of October 23, 2018, this version worked.)
   ```
   defp deps do
       [

--- a/README.md
+++ b/README.md
@@ -143,18 +143,18 @@ Close the monitor:
 1. In the Erlang/OTP 21, erlport may not be compiled, because the latest version was not reflected in the official Erlport GitHub.
 
   - SOL) Change the version of erlport manually in <b>mix.exs</b>. As of October, 2018, the "0.10.0" version worked. See this https://github.com/hdima/erlport
-  ```
-  defp deps do
-      [
-        {:erlport, "~> 0.10.0"}, # Choose the version.
-        {:poolboy, "~> 1.5"}
-      ]
-  end
-  ```
+    ```
+    defp deps do
+        [
+          {:erlport, "~> 0.10.0"}, # Choose the version.
+          {:poolboy, "~> 1.5"}
+        ]
+    end
+    ```
   
 2. Failed to fetch record for 'hexpm/poolboy' from registry (using cache)
 
   - SOL) This was a cache problem, remove the cache file and try again.
-  ```
-  rm "~/.hex/cache.ets"
-  ```
+    ```
+    rm "~/.hex/cache.ets"
+    ```

--- a/README.md
+++ b/README.md
@@ -151,3 +151,10 @@ Close the monitor:
       ]
   end
   ```
+  
+2. Failed to fetch record for 'hexpm/poolboy' from registry (using cache)
+
+  - SOL) This was a cache problem, remove the cache file and try again.
+  ```
+  rm "~/.hex/cache.ets"
+  ```

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Close the monitor:
     ```
     rm "~/.hex/cache.ets"
     ```
-<b>3. When you run a client, if you get the following error.
+<b>3. When you run a client, if you get the following error.</b>
     ```
     $ ./example
     terminate called after throwing an instance of 'boost::system::system_error'

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Close the monitor:
   ```
   defp deps do
       [
-        {:erlport, "~> 0.10.0"},
+        {:erlport, "~> 0.10.0"}, # Choose the version.
         {:poolboy, "~> 1.5"}
       ]
   end

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Close the monitor:
     rm "~/.hex/cache.ets"
     ```
     
-<b>3. When you run a client, <b>what():  Connection refused.</b> error occurs
+<b>3. When you run a client, <b>what():  Connection refused.</b> error occurs</b>
   
   - SOL) I changed the line 17 code const std::string host = "kurg.org"; to const std::string host = "127.0.0.1"; in example.cpp and then the program is working correctly. This is to use your own server instance.
   ```

--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,7 @@ defmodule GymTcpApi.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
-      {:erlport, git: "https://github.com/hdima/erlport.git"},
+      {:erlport, "~> 0.10.0"},
       {:poolboy, "~> 1.5"}
     ]
   end


### PR DESCRIPTION
Current erlport version cannot be compiled in Erlang/OTP21. And I fixed the problem by upgrading the version.