### PR TITLE
Updated the OpenAI Gym dependency version and Added FAQ 3.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The server is written in elixir, enabling a distributed infrastructure. Where ea
 The server has the following dependencies:
 
     Elixir >= 1.0
-    OpenAI Gym
+    OpenAI Gym <= 0.9.5
 
 The c++ example agent has the following dependencies:
 
@@ -159,3 +159,9 @@ Close the monitor:
     rm "~/.hex/cache.ets"
     ```
     
+<b>3. ImportError, cannot import name Monitor</b>
+  
+  - SOL) We guess the OpenAI gym's interface has been changed, hence can you try to downgrade the gym version?
+    ```
+    pip install gym==0.9.5
+    ```


### PR DESCRIPTION
Hi @zoq. This is related to #10 .
I guess the OpenAI gym's interface has been changed. 
```
14:11:03.536 [error] GenServer #PID<0.160.0> terminating
** (stop) {:python, :"builtins.ImportError", 'cannot import name \'Monitor\'', {:"$erlport.opaque", :python, <<128, 2, 99, 116, 114, 97, 99, 101, 98, 97, 99, 107, 10, 83, 116, 97, 99, 107, 83, 117, 109, 109, 97, 114, 121, 10, 113, 0, 41, 129, 113, 1, 40, 99, 116, 114, 97, 99, 101, 98, 97, 99, 107, 10, 70, ...>>}}
    /home/sy0814k/Desktop/KSY/gym_tcp_api/deps/erlport/src/erlport.erl:234: :erlport.call/3
    (gym_tcp_api) lib/worker.ex:25: GymTcpApi.Worker.handle_call/3
    (stdlib) gen_server.erl:636: :gen_server.try_handle_call/4
    (stdlib) gen_server.erl:665: :gen_server.handle_msg/6
    (stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3
Last message (from #PID<0.167.0>): {"{\"env\":{\"name\": \"CartPole-v0\"}}\r\n", #PID<0.166.0>}
State: #PID<0.161.0>
Client #PID<0.167.0> is alive
    (stdlib) gen.erl:169: :gen.do_call/4
    (stdlib) gen_server.erl:202: :gen_server.call/2
    (gym_tcp_api) lib/worker.ex:40: GymTcpApi.Worker.process/
```
This issue can be avoided by downgrading Gym's version. So, I updated our `README.md` and added `FAQ 3` about how to downgrade Gym's version.