### PR TITLE
Fix re-ordering warnings

### DIFF
--- a/cpp/client.hpp
+++ b/cpp/client.hpp
@@ -34,9 +34,9 @@ class Client
 {
  public:
   static void async_read_handler(const boost::system::error_code& err,
-                        boost::system::error_code* err_out,
-                        std::size_t bytes_transferred,
-                        std::size_t* bytes_out)
+                                 boost::system::error_code* err_out,
+                                 std::size_t bytes_transferred,
+                                 std::size_t* bytes_out)
   {
     *err_out = err;
     *bytes_out = bytes_transferred;
@@ -199,10 +199,10 @@ class Client
   //! Locally stored io service.
   boost::asio::io_service io_service;
 
-  deadline_timer deadline;
-
   //! Locally stored socket object.
   tcp::socket s;
+
+  deadline_timer deadline;
 
   //! Locally-stored compression parameter.
   size_t compressionLevel;

--- a/cpp/client.hpp
+++ b/cpp/client.hpp
@@ -202,6 +202,7 @@ class Client
   //! Locally stored socket object.
   tcp::socket s;
 
+  //! Object to control connection timeouts.
   deadline_timer deadline;
 
   //! Locally-stored compression parameter.


### PR DESCRIPTION
This pull request fixes only the re-ordering warning from client.hpp
@zoq if you would like, I think we can fix all warnings from pjson.

Signed-off-by: Omar Shrit <omar@shrit.me>